### PR TITLE
Fix indexing in setting eTotalCapCharge max and min

### DIFF
--- a/src/GenX/model/resources/storage/investment_charge.jl
+++ b/src/GenX/model/resources/storage/investment_charge.jl
@@ -117,11 +117,11 @@ function investment_charge(EP::Model, inputs::Dict)
 
 	# Constraint on maximum charge capacity (if applicable) [set input to -1 if no constraint on maximum charge capacity]
 	# DEV NOTE: This constraint may be violated in some cases where Existing_Charge_Cap_MW is >= Max_Charge_Cap_MWh and lead to infeasabilty
-	@constraint(EP, cMaxCapCharge[y in intersect(dfGen[!,:Max_Charge_Cap_MW].>0, STOR_ASYMMETRIC)], eTotalCapCharge[y] <= dfGen[!,:Max_Charge_Cap_MW][y])
+    @constraint(EP, cMaxCapCharge[y in intersect(dfGen[dfGen.Max_Charge_Cap_MW.>0,:R_ID], STOR_ASYMMETRIC)], eTotalCapCharge[y] <= dfGen[y,:Max_Charge_Cap_MW])
 
 	# Constraint on minimum charge capacity (if applicable) [set input to -1 if no constraint on minimum charge capacity]
 	# DEV NOTE: This constraint may be violated in some cases where Existing_Charge_Cap_MW is <= Min_Charge_Cap_MWh and lead to infeasabilty
-	@constraint(EP, cMinCapCharge[y in intersect(dfGen[!,:Min_Charge_Cap_MW].>0, STOR_ASYMMETRIC)], eTotalCapCharge[y] >= dfGen[!,:Min_Charge_Cap_MW][y])
+	@constraint(EP, cMinCapCharge[y in intersect(dfGen[dfGen.Min_Charge_Cap_MW.>0,:R_ID], STOR_ASYMMETRIC)], eTotalCapCharge[y] >= dfGen[y,:Min_Charge_Cap_MW])
 
 	return EP
 end


### PR DESCRIPTION
An indexing bug means GenX doesn't currently respect the eTotalCapCharge < Max_Charge_Cap_MW constraint. I've been shown cases where an asymmetric storage technology has the correct max discharge capacity and energy capacity, but not charge capacity.

We've tested the system with a STOR==2 technology and setting the constraint on the eTotalCapCharge[y] expression and GenX is now respecting the eTotalCapCharge < Max_Charge_Cap_MW constraint properly