### PR TITLE
Updated year and GenX->Dolphyn in configure_highs.jl

### DIFF
--- a/src/configure_solver/configure_highs.jl
+++ b/src/configure_solver/configure_highs.jl
@@ -1,6 +1,6 @@
 """
-GenX: An Configurable Capacity Expansion Model
-Copyright (C) 2021,  Massachusetts Institute of Technology
+DOLPHYN: Decision Optimization for Low-carbon Power and Hydrogen Networks
+Copyright (C) 2022,  Massachusetts Institute of Technology
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or


### PR DESCRIPTION
This was the only typo I could find in the repo.