### PR TITLE
Added backup line-by-line file comparison

### DIFF
--- a/Example_Systems/2030_CombEC_DETrans/Check_results.jl
+++ b/Example_Systems/2030_CombEC_DETrans/Check_results.jl
@@ -58,7 +58,10 @@ push!(LOAD_PATH, src_path)
 
 using DOLPHYN
 
-outpath = "$inpath/Results"
+outpath = joinpath(inpath, "Results")
 
 summary_path = joinpath(inpath, "summary.txt")
-compare_results(joinpath(inpath, "Results_Example"), outpath, summary_path)
+example_path = joinpath(inpath, "Results_Example")
+println("Comparing $(example_path) and $(outpath)")
+println("Writing summary to $(summary_path)")
+compare_results(example_path, outpath, summary_path)

--- a/Example_Systems/SmallNewEngland/OneZone/Check_results.jl
+++ b/Example_Systems/SmallNewEngland/OneZone/Check_results.jl
@@ -58,7 +58,10 @@ push!(LOAD_PATH, src_path)
 
 using DOLPHYN
 
-outpath = "$inpath/Results"
+outpath = joinpath(inpath, "Results")
 
 summary_path = joinpath(inpath, "summary.txt")
-compare_results(joinpath(inpath, "Results_Example"), outpath, summary_path)
+example_path = joinpath(inpath, "Results_Example")
+println("Comparing $(example_path) and $(outpath)")
+println("Writing summary to $(summary_path)")
+compare_results(example_path, outpath, summary_path)

--- a/Example_Systems/SmallNewEngland/ThreeZones/Check_results.jl
+++ b/Example_Systems/SmallNewEngland/ThreeZones/Check_results.jl
@@ -58,7 +58,10 @@ push!(LOAD_PATH, src_path)
 
 using DOLPHYN
 
-outpath = "$inpath/Results"
+outpath = joinpath(inpath, "Results")
 
 summary_path = joinpath(inpath, "summary.txt")
-compare_results(joinpath(inpath, "Results_Example"), outpath, summary_path)
+example_path = joinpath(inpath, "Results_Example")
+println("Comparing $(example_path) and $(outpath)")
+println("Writing summary to $(summary_path)")
+compare_results(example_path, outpath, summary_path)


### PR DESCRIPTION
Our result files have slightly changed recently, including adding one or two bytes to otherwise identical files. This breaks the byte-wise result comparison, so I have added a back-up method using line-by-line string comparison.

It's slower but we could also use it to highlight which lines are different.

Eventually, we should automatically update the /Result_Example files which each merge / release.