### PR TITLE
Allow Julia 1.8 with DOLPHYN

### DIFF
--- a/src/GenX/write_outputs/capacity_reserve_margin/write_capacity_value.jl
+++ b/src/GenX/write_outputs/capacity_reserve_margin/write_capacity_value.jl
@@ -40,7 +40,7 @@ function write_capacity_value(path::AbstractString, sep::AbstractString, inputs:
 		dfCapValue_ = select!(dfCapValue_, Not(:AnnualSum))
 		if v"1.3" <= VERSION < v"1.4"
 			dfCapValue_[!,:Reserve] .= Symbol("CapRes_$i")
-		elseif v"1.4" <= VERSION < v"1.8"
+		elseif v"1.4" <= VERSION < v"1.9"
 			#dfCapValue_.Reserve = Symbol("CapRes_$i")
 			dfCapValue_.Reserve = fill(Symbol("CapRes_$i"), size(dfCapValue_, 1))
 		end

--- a/src/GenX/write_outputs/transmission/write_transmission_flows.jl
+++ b/src/GenX/write_outputs/transmission/write_transmission_flows.jl
@@ -43,7 +43,7 @@ function write_transmission_flows(path::AbstractString, sep::AbstractString, set
 	for t in 1:T
 		if v"1.3" <= VERSION < v"1.4"
 			total[!,t+2] .= sum(dfFlow[!,Symbol("t$t")][1:L])
-		elseif v"1.4" <= VERSION < v"1.8"
+		elseif v"1.4" <= VERSION < v"1.9"
 			total[:,t+2] .= sum(dfFlow[:,Symbol("t$t")][1:L])
 		end
 		

--- a/src/GenX/write_outputs/transmission/write_transmission_losses.jl
+++ b/src/GenX/write_outputs/transmission/write_transmission_losses.jl
@@ -51,7 +51,7 @@ function write_transmission_losses(path::AbstractString, sep::AbstractString, in
 	for t in 1:T
 		if v"1.3" <= VERSION < v"1.4"
 			total[!,t+2] .= sum(dfTLosses[!,Symbol("t$t")][1:L])
-		elseif v"1.4" <= VERSION < v"1.8"
+		elseif v"1.4" <= VERSION < v"1.9"
 			total[:,t+2] .= sum(dfTLosses[:,Symbol("t$t")][1:L])
 		end
 		

--- a/src/GenX/write_outputs/ucommit/write_shutdown.jl
+++ b/src/GenX/write_outputs/ucommit/write_shutdown.jl
@@ -41,7 +41,7 @@ function write_shutdown(path::AbstractString, sep::AbstractString, inputs::Dict,
 	for t in 1:T
 		if v"1.3" <= VERSION < v"1.4"
 			total[!,t+3] .= sum(dfShutdown[!,Symbol("t$t")][1:G])
-		elseif v"1.4" <= VERSION < v"1.8"
+		elseif v"1.4" <= VERSION < v"1.9"
 			total[:,t+3] .= sum(dfShutdown[:,Symbol("t$t")][1:G])
 		end
 	end

--- a/src/GenX/write_outputs/write_charge.jl
+++ b/src/GenX/write_outputs/write_charge.jl
@@ -49,7 +49,7 @@ function write_charge(path::AbstractString, sep::AbstractString, inputs::Dict, s
 	for t in 1:T
 		if v"1.3" <= VERSION < v"1.4"
 			total[!,t+3] .= sum(dfCharge[!,Symbol("t$t")][union(inputs["STOR_ALL"],inputs["FLEX"])])
-		elseif v"1.4" <= VERSION < v"1.8"
+		elseif v"1.4" <= VERSION < v"1.9"
 			total[:,t+3] .= sum(dfCharge[:,Symbol("t$t")][union(inputs["STOR_ALL"],inputs["FLEX"])])
 		end
 	end

--- a/src/GenX/write_outputs/write_curtailment.jl
+++ b/src/GenX/write_outputs/write_curtailment.jl
@@ -45,7 +45,7 @@ function write_curtailment(path::AbstractString, sep::AbstractString, inputs::Di
 	for t in 1:T
 		if v"1.3" <= VERSION < v"1.4"
 			total[!,t+3] .= sum(dfCurtailment[!,Symbol("t$t")][1:G])
-		elseif v"1.4" <= VERSION < v"1.8"
+		elseif v"1.4" <= VERSION < v"1.9"
 			total[:,t+3] .= sum(dfCurtailment[:,Symbol("t$t")][1:G])
 		end
 	end

--- a/src/GenX/write_outputs/write_emissions.jl
+++ b/src/GenX/write_outputs/write_emissions.jl
@@ -75,7 +75,7 @@ function write_emissions(path::AbstractString, sep::AbstractString, inputs::Dict
 			for t in 1:T
 				if v"1.3" <= VERSION < v"1.4"
 					total[!,t+inputs["NCO2Cap"]+2] .= sum(dfEmissions[!,Symbol("t$t")][1:Z])
-				elseif v"1.4" <= VERSION < v"1.8"
+				elseif v"1.4" <= VERSION < v"1.9"
 					total[:,t+inputs["NCO2Cap"]+2] .= sum(dfEmissions[:,Symbol("t$t")][1:Z])
 				end
 			end
@@ -88,7 +88,7 @@ function write_emissions(path::AbstractString, sep::AbstractString, inputs::Dict
 			for t in 1:T
 				if v"1.3" <= VERSION < v"1.4"
 					total[!,t+2] .= sum(dfEmissions[!,Symbol("t$t")][1:Z])
-				elseif v"1.4" <= VERSION < v"1.8"
+				elseif v"1.4" <= VERSION < v"1.9"
 					total[:,t+2] .= sum(dfEmissions[:,Symbol("t$t")][1:Z])
 				end
 			end
@@ -119,7 +119,7 @@ function write_emissions(path::AbstractString, sep::AbstractString, inputs::Dict
 		for t in 1:T
 			if v"1.3" <= VERSION < v"1.4"
 				total[!,t+2] .= sum(dfEmissions[!,Symbol("t$t")][1:Z])
-			elseif v"1.4" <= VERSION < v"1.8"
+			elseif v"1.4" <= VERSION < v"1.9"
 				total[:,t+2] .= sum(dfEmissions[:,Symbol("t$t")][1:Z])
 			end
 		end

--- a/src/GenX/write_outputs/write_net_revenue.jl
+++ b/src/GenX/write_outputs/write_net_revenue.jl
@@ -50,7 +50,7 @@ function write_net_revenue(path::AbstractString, sep::AbstractString, inputs::Di
 	# Add fuel cost to the dataframe
 	if v"1.3" <= VERSION < v"1.4"
 		dfNetRevenue[!,:Fuel_cost] .= 0.0
-	elseif v"1.4" <= VERSION < v"1.8"
+	elseif v"1.4" <= VERSION < v"1.9"
 		dfNetRevenue.Fuel_cost = zeros(size(dfNetRevenue, 1))
 	end
 	for i in 1:G
@@ -63,7 +63,7 @@ function write_net_revenue(path::AbstractString, sep::AbstractString, inputs::Di
 	# Add storage cost to the dataframe
 	if v"1.3" <= VERSION < v"1.4"
 		dfNetRevenue[!,:Var_OM_cost_in] .= 0.0
-	elseif v"1.4" <= VERSION < v"1.8"
+	elseif v"1.4" <= VERSION < v"1.9"
 		dfNetRevenue.Var_OM_cost_in = zeros(size(dfNetRevenue, 1))
 	end
  	for y in inputs["STOR_ALL"]
@@ -75,7 +75,7 @@ function write_net_revenue(path::AbstractString, sep::AbstractString, inputs::Di
 	# Add start-up cost to the dataframe
 	if v"1.3" <= VERSION < v"1.4"
 		dfNetRevenue[!,:StartCost] .= 0.0
-	elseif v"1.4" <= VERSION < v"1.8"
+	elseif v"1.4" <= VERSION < v"1.9"
 		dfNetRevenue.StartCost = zeros(size(dfNetRevenue, 1))
 	end
  	if (setup["UCommit"]>=1)
@@ -89,7 +89,7 @@ function write_net_revenue(path::AbstractString, sep::AbstractString, inputs::Di
 	# Add charge cost to the dataframe
 	if v"1.3" <= VERSION < v"1.4"
 		dfNetRevenue[!,:Charge_cost] .= 0.0
-	elseif v"1.4" <= VERSION < v"1.8"
+	elseif v"1.4" <= VERSION < v"1.9"
 		dfNetRevenue.Charge_cost = zeros(size(dfNetRevenue, 1))
 	end
 	if has_duals(EP) == 1
@@ -100,7 +100,7 @@ function write_net_revenue(path::AbstractString, sep::AbstractString, inputs::Di
 	if v"1.3" <= VERSION < v"1.4"
 		dfNetRevenue[!,:EnergyRevenue] .= 0.0
 		dfNetRevenue[!,:SubsidyRevenue] .= 0.0
-	elseif v"1.4" <= VERSION < v"1.8"
+	elseif v"1.4" <= VERSION < v"1.9"
 		dfNetRevenue.EnergyRevenue = zeros(size(dfNetRevenue, 1))
 		dfNetRevenue.SubsidyRevenue = zeros(size(dfNetRevenue, 1))
 	end
@@ -112,7 +112,7 @@ function write_net_revenue(path::AbstractString, sep::AbstractString, inputs::Di
 	# Add capacity revenue to the dataframe
 	if v"1.3" <= VERSION < v"1.4"
 		dfNetRevenue[!,:ReserveMarginRevenue] .= 0.0
-	elseif v"1.4" <= VERSION < v"1.8"
+	elseif v"1.4" <= VERSION < v"1.9"
 		dfNetRevenue.ReserveMarginRevenue = zeros(size(dfNetRevenue, 1))
 	end
  	if setup["CapacityReserveMargin"] > 0 && has_duals(EP) == 1 # The unit is confirmed to be $
@@ -122,7 +122,7 @@ function write_net_revenue(path::AbstractString, sep::AbstractString, inputs::Di
 	# Add RPS/CES revenue to the dataframe
 	if v"1.3" <= VERSION < v"1.4"
 		dfNetRevenue[!,:ESRRevenue] .= 0.0
-	elseif v"1.4" <= VERSION < v"1.8"
+	elseif v"1.4" <= VERSION < v"1.9"
 		dfNetRevenue.ESRRevenue = zeros(size(dfNetRevenue, 1))
 	end
  	if setup["EnergyShareRequirement"] > 0 && has_duals(EP) == 1 # The unit is confirmed to be $
@@ -132,7 +132,7 @@ function write_net_revenue(path::AbstractString, sep::AbstractString, inputs::Di
 	# Calculate emissions cost
 	if v"1.3" <= VERSION < v"1.4"
 		dfNetRevenue[!,:EmissionsCost] .= 0.0
-	elseif v"1.4" <= VERSION < v"1.8"
+	elseif v"1.4" <= VERSION < v"1.9"
 		dfNetRevenue.EmissionsCost = zeros(size(dfNetRevenue, 1))
 	end
  	if setup["CO2Cap"] >=1 && has_duals(EP) == 1
@@ -167,7 +167,7 @@ function write_net_revenue(path::AbstractString, sep::AbstractString, inputs::Di
 	# Add regional technology subsidy revenue to the dataframe
 	if v"1.3" <= VERSION < v"1.4"
 		dfNetRevenue[!,:RegSubsidyRevenue] .= 0.0
-	elseif v"1.4" <= VERSION < v"1.8"
+	elseif v"1.4" <= VERSION < v"1.9"
 		dfNetRevenue.RegSubsidyRevenue = zeros(size(dfNetRevenue, 1))
 	end
 	if setup["MinCapReq"] >= 1 && has_duals(EP) == 1 # The unit is confirmed to be US$

--- a/src/GenX/write_outputs/write_nse.jl
+++ b/src/GenX/write_outputs/write_nse.jl
@@ -55,7 +55,7 @@ function write_nse(path::AbstractString, sep::AbstractString, inputs::Dict, setu
 	for t in 1:T
 		if v"1.3" <= VERSION < v"1.4"
 			total[!,t+3] .= sum(dfNse[!,Symbol("t$t")][1:Z])
-		elseif v"1.4" <= VERSION < v"1.8"
+		elseif v"1.4" <= VERSION < v"1.9"
 			total[:,t+3] .= sum(dfNse[:,Symbol("t$t")][1:Z])
 		end
 	end

--- a/src/GenX/write_outputs/write_power.jl
+++ b/src/GenX/write_outputs/write_power.jl
@@ -45,7 +45,7 @@ function write_power(path::AbstractString, sep::AbstractString, inputs::Dict, se
 	for t in 1:T
 		if v"1.3" <= VERSION < v"1.4"
 			total[!,t+3] .= sum(dfPower[!,Symbol("t$t")][1:G])
-		elseif v"1.4" <= VERSION < v"1.8"
+		elseif v"1.4" <= VERSION < v"1.9"
 			total[:,t+3] .= sum(dfPower[:,Symbol("t$t")][1:G])
 		end
 	end

--- a/src/GenX/write_outputs/write_subsidy_revenue.jl
+++ b/src/GenX/write_outputs/write_subsidy_revenue.jl
@@ -28,7 +28,7 @@ function write_subsidy_revenue(path::AbstractString, sep::AbstractString, inputs
 	
 	if v"1.3" <= VERSION < v"1.4"
 		dfSubRevenue[!,:SubsidyRevenue] .= 0.0
-	elseif v"1.4" <= VERSION < v"1.8"
+	elseif v"1.4" <= VERSION < v"1.9"
 		dfSubRevenue.SubsidyRevenue = zeros(size(dfSubRevenue, 1))
 		#dfSubRevenue[:,:SubsidyRevenue] = zeros(size(dfSubRevenue, 1))
 	end
@@ -47,7 +47,7 @@ function write_subsidy_revenue(path::AbstractString, sep::AbstractString, inputs
 	#dfRegSubRevenue.SubsidyRevenue .= 0.0
 	if v"1.3" <= VERSION < v"1.4"
 		dfRegSubRevenue[!,:SubsidyRevenue] .= 0.0
-	elseif v"1.4" <= VERSION < v"1.8"
+	elseif v"1.4" <= VERSION < v"1.9"
 		dfRegSubRevenue.SubsidyRevenue = zeros(size(dfRegSubRevenue, 1))
 	end
 	if (setup["MinCapReq"] >= 1)

--- a/src/HSC/write_outputs/write_h2_charge.jl
+++ b/src/HSC/write_outputs/write_h2_charge.jl
@@ -42,7 +42,7 @@ function write_h2_charge(path::AbstractString, sep::AbstractString, inputs::Dict
 	for t in 1:T
 		if v"1.3" <= VERSION < v"1.4"
 			total[!,t+3] .= sum(dfCharge[!,Symbol("t$t")][union(inputs["H2_STOR_ALL"],inputs["H2_FLEX"])])
-		elseif v"1.4" <= VERSION < v"1.8"
+		elseif v"1.4" <= VERSION < v"1.9"
 			total[:,t+3] .= sum(dfCharge[:,Symbol("t$t")][union(inputs["H2_STOR_ALL"],inputs["H2_FLEX"])])
 		end
 	end

--- a/src/HSC/write_outputs/write_h2_emissions.jl
+++ b/src/HSC/write_outputs/write_h2_emissions.jl
@@ -69,7 +69,7 @@ function write_h2_emissions(path::AbstractString, sep::AbstractString, inputs::D
 		for t in 1:T
 			if v"1.3" <= VERSION < v"1.4"
 				total[!,t+inputs["H2NCO2Cap"]+2] .= sum(dfEmissions[!,Symbol("t$t")][1:Z])
-			elseif v"1.4" <= VERSION < v"1.8"
+			elseif v"1.4" <= VERSION < v"1.9"
 				total[:,t+inputs["H2NCO2Cap"]+2] .= sum(dfEmissions[:,Symbol("t$t")][1:Z])
 			end
 		end
@@ -82,7 +82,7 @@ function write_h2_emissions(path::AbstractString, sep::AbstractString, inputs::D
 		for t in 1:T
 			if v"1.3" <= VERSION < v"1.4"
 				total[!,t+2] .= sum(dfEmissions[!,Symbol("t$t")][1:Z])
-			elseif v"1.4" <= VERSION < v"1.8"
+			elseif v"1.4" <= VERSION < v"1.9"
 				total[:,t+2] .= sum(dfEmissions[:,Symbol("t$t")][1:Z])
 			end
 		end

--- a/src/HSC/write_outputs/write_h2_nse.jl
+++ b/src/HSC/write_outputs/write_h2_nse.jl
@@ -50,7 +50,7 @@ function write_h2_nse(path::AbstractString, sep::AbstractString, inputs::Dict, s
 	for t in 1:T
 		if v"1.3" <= VERSION < v"1.4"
 			total[!,t+3] .= sum(dfNse[!,Symbol("t$t")][1:Z])
-		elseif v"1.4" <= VERSION < v"1.8"
+		elseif v"1.4" <= VERSION < v"1.9"
 			total[:,t+3] .= sum(dfNse[:,Symbol("t$t")][1:Z])
 		end
 	end


### PR DESCRIPTION
DOLPHYN is hard-coded to only allow up to Julia v1.7.x . This extends that to v1.8.x

Eventually we should update our version of GenX, as the most recent versions have removed all this hard-coding.