### PR TITLE
Fixed a bug in the environment-making script for cases where Gurobi version >= v10.0

### DIFF
--- a/julenv.jl
+++ b/julenv.jl
@@ -21,7 +21,9 @@ function get_gurobi_version()
     try
         res = read(`gurobi_cl --version`, String)
         res = split(res, ".")
-        gurobi_ver = string("$(res[1][end]).$(res[2])")
+        major = split(res[1], " ")[end]
+        minor = res[2]
+        gurobi_ver = string("$(major).$(minor)")
         gurobi_ver = parse(Float64, gurobi_ver)
         return gurobi_ver
     catch e


### PR DESCRIPTION
The Julia package for Gurobi requires the user to have an appropriate version of Gurobi installed.

v0.11.4 onwards of the Julia package don't work with v10.0+ of Gurobi, so the environment-making script checks which version is installed and then either include v0.11.3 or v0.11.4 of the Julia package.

There was a bug in the version-checking function which meant it didn't work in all cases. This should now be fixed.