### PR TITLE
Include Output scaling for transmission outputs

### DIFF
--- a/src/GenX/write_outputs/transmission/write_nw_expansion.jl
+++ b/src/GenX/write_outputs/transmission/write_nw_expansion.jl
@@ -33,5 +33,10 @@ function write_nw_expansion(path::AbstractString, sep::AbstractString, inputs::D
 	Line = 1:L, New_Trans_Capacity = convert(Array{Union{Missing,Float32}}, transcap),
 	Cost_Trans_Capacity = convert(Array{Union{Missing,Float32}}, transcap.*inputs["pC_Line_Reinforcement"]),
 	)
+
+	if setup["ParameterScale"] == 1
+		dfTransCap.New_Trans_Capacity *= ModelScalingFactor  # GW to MW
+		dfTransCap.Cost_Trans_Capacity *= ModelScalingFactor^2  # MUSD to USD
+	end
 	CSV.write(string(path,sep,"network_expansion.csv"), dfTransCap)
 end


### PR DESCRIPTION
Add if condition to scale model outputs related to transmission expansion  (capacity and cost) depending on value of model settings ParameterScale (either 0 or 1).