### PR TITLE
Track power balance using expressions

### DIFF
--- a/src/GenX/model/core/non_served_energy.jl
+++ b/src/GenX/model/core/non_served_energy.jl
@@ -98,10 +98,12 @@ function non_served_energy(EP::Model, inputs::Dict)
 
 	## Power Balance Expressions ##
 	@expression(EP, ePowerBalanceNse[t=1:T, z=1:Z], sum(vNSE[s,t,z] for s=1:SEG))
-
+	@expression(EP, ePowerNseByZone[z=1:Z, t=1:T], sum(vNSE[s,t,z] for s=1:SEG))
 	# Add non-served energy/curtailed demand contribution to power balance expression
 	EP[:ePowerBalance] += ePowerBalanceNse
 
+	# Minus non served demand from input demand
+	EP[:eDemandByZone] -= EP[:ePowerNseByZone]
 	### Constratints ###
 
 	# Demand curtailed in each segment of curtailable demands cannot exceed maximum allowable share of demand

--- a/src/GenX/model/core/non_served_energy.jl
+++ b/src/GenX/model/core/non_served_energy.jl
@@ -98,12 +98,12 @@ function non_served_energy(EP::Model, inputs::Dict)
 
 	## Power Balance Expressions ##
 	@expression(EP, ePowerBalanceNse[t=1:T, z=1:Z], sum(vNSE[s,t,z] for s=1:SEG))
-	@expression(EP, ePowerNseByZone[z=1:Z, t=1:T], sum(vNSE[s,t,z] for s=1:SEG))
+
 	# Add non-served energy/curtailed demand contribution to power balance expression
 	EP[:ePowerBalance] += ePowerBalanceNse
 
 	# Minus non served demand from input demand
-	EP[:eDemandByZone] -= EP[:ePowerNseByZone]
+	EP[:eDemandByZone] -= ePowerBalanceNse
 	### Constratints ###
 
 	# Demand curtailed in each segment of curtailable demands cannot exceed maximum allowable share of demand

--- a/src/GenX/model/core/transmission.jl
+++ b/src/GenX/model/core/transmission.jl
@@ -245,6 +245,10 @@ function transmission(EP::Model, inputs::Dict, UCommit::Int, NetworkExpansion::I
 	# Losses from power flows into or out of zone "z" in MW
     @expression(EP, eLosses_By_Zone[z=1:Z,t=1:T], sum(abs(inputs["pNet_Map"][l,z]) * vTLOSS[l,t] for l in LOSS_LINES))
 
+	# Record power flow and losses by zone into transmission expression
+	EP[:eTransmissionByZone] += EP[:eNet_Export_Flows]
+	EP[:eTransmissionByZone] += EP[:eLosses_By_Zone]
+
 	## Objective Function Expressions ##
 
 	if NetworkExpansion == 1

--- a/src/GenX/write_outputs/write_power_balance.jl
+++ b/src/GenX/write_outputs/write_power_balance.jl
@@ -1,5 +1,5 @@
 """
-DOLPHYN: Decision Optimization for Low-carbon Power and Hydrogen Nexus
+DOLPHYN: Decision Optimization for Low-carbon Power and Hydrogen Networks
 Copyright (C) 2022,  Massachusetts Institute of Technology
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -15,11 +15,11 @@ received this license file.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 @doc raw"""
-	write_power_balance(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+	write_power_balance(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 
 Function for reporting power balance of resources across different zones.
 """
-function write_power_balance(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+function write_power_balance(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	dfGen = inputs["dfGen"]
 	
 	if setup["ModelH2"] == 1
@@ -42,7 +42,7 @@ function write_power_balance(path::AbstractString, inputs::Dict, setup::Dict, EP
 	           "Flexible_Demand_Defer", "Flexible_Demand_Stasify",
 	           "Demand_Response", "Nonserved_Energy",
 			   "Transmission_NetExport", "Transmission_Losses","HSC_Consumption",
-	           "Demand", "Transmission", "AdditionalDemand"]
+	           "Demand", "Transmission", "Additional Demand"]
 	   	dfTemp1[2,1:size(dfTemp1,2)] = repeat([z],size(dfTemp1,2))
 	   	for t in 1:T
 	     	dfTemp1[t+rowoffset,1]= sum(value.(EP[:vP][dfGen[(dfGen[!,:THERM].>=1) .&  (dfGen[!,:Zone].==z),:][!,:R_ID],t])) +
@@ -72,34 +72,34 @@ function write_power_balance(path::AbstractString, inputs::Dict, setup::Dict, EP
 	     	end
 	     	dfTemp1[t+rowoffset,6] = -sum(value.(EP[:vP][dfGen[(dfGen[!,:FLEX].>=1) .&  (dfGen[!,:Zone].==z),:][!,:R_ID],t]))
 	     	if SEG>1
-	       		dfTemp1[t+rowoffset,7] = sum(value.(EP[:vNSE][2:SEG,z,t]))
+	       		dfTemp1[t+rowoffset,7] = sum(value.(EP[:vNSE][2:SEG,t,z]))
 	     	else
 	       		dfTemp1[t+rowoffset,7]=0
 	     	end
-	     	dfTemp1[t+rowoffset,8] = value(EP[:vNSE][1,z,t])
+	     	dfTemp1[t+rowoffset,8] = value(EP[:vNSE][1,t,z])
 	     	dfTemp1[t+rowoffset,9] = 0
 	     	dfTemp1[t+rowoffset,10] = 0
 
 			if Z>=2
-				dfTemp1[t+rowoffset,9] = value(EP[:ePowerBalanceNetExportFlows][z,t])
+				dfTemp1[t+rowoffset,9] = value(EP[:ePowerBalanceNetExportFlows][t,z])
 				dfTemp1[t+rowoffset,10] = -1/2 * value(EP[:eLosses_By_Zone][z,t])
 			end
 
 			if setup["ModelH2"] == 1
-				dfTemp1[t+rowoffset,11] = -value(EP[:eH2NetpowerConsumptionByAll][z,t])
+				dfTemp1[t+rowoffset,11] = -value(EP[:eH2NetpowerConsumptionByAll][t,z])
 			else
 				dfTemp1[t+rowoffset,11] = 0
 			end
 
-	     	dfTemp1[t+rowoffset,12] = -value(EP[:eDemandByZone][z,t])
+	     	dfTemp1[t+rowoffset,12] = -inputs["pD"][t,z]
 
 			dfTemp1[t+rowoffset,13] = 0
 
 			if Z>=2
-				dfTemp1[t+rowoffset,13] = value(EP[:ePTransmission][z,t])
+				dfTemp1[t+rowoffset,13] = value(EP[:eTransmissionByZone][z,t])
 			end
-
-			dfTemp1[t+rowoffset,14] = value(EP[:ePDemandAddition][z,t])
+				
+			dfTemp1[t+rowoffset,14] = value(EP[:eAdditionalDemand][z,t])
 
 			if setup["ParameterScale"] == 1
 				dfTemp1[t+rowoffset,1] = dfTemp1[t+rowoffset,1] * ModelScalingFactor
@@ -114,6 +114,8 @@ function write_power_balance(path::AbstractString, inputs::Dict, setup::Dict, EP
 				dfTemp1[t+rowoffset,10] = dfTemp1[t+rowoffset,10] * ModelScalingFactor
 				dfTemp1[t+rowoffset,11] = dfTemp1[t+rowoffset,11] * ModelScalingFactor
 				dfTemp1[t+rowoffset,12] = dfTemp1[t+rowoffset,12] * ModelScalingFactor
+				dfTemp1[t+rowoffset,13] = dfTemp1[t+rowoffset,13] * ModelScalingFactor
+				dfTemp1[t+rowoffset,14] = dfTemp1[t+rowoffset,14] * ModelScalingFactor
 			end
 			# DEV NOTE: need to add terms for electricity consumption from H2 balance
 	   	end
@@ -127,5 +129,5 @@ function write_power_balance(path::AbstractString, inputs::Dict, setup::Dict, EP
 	   	dfPowerBalance[rowoffset,c]=sum(inputs["omega"].*dfPowerBalance[(rowoffset+1):size(dfPowerBalance,1),c])
 	end
 	dfPowerBalance = DataFrame(dfPowerBalance, :auto)
-	CSV.write(joinpath(path, "power_balance.csv"), dfPowerBalance, writeheader=false)
+	CSV.write(string(path,sep,"power_balance.csv"), dfPowerBalance, writeheader=false)
 end

--- a/src/GenX/write_outputs/write_power_balance.jl
+++ b/src/GenX/write_outputs/write_power_balance.jl
@@ -99,7 +99,7 @@ function write_power_balance(path::AbstractString, sep::AbstractString, inputs::
 				dfTemp1[t+rowoffset,13] = value(EP[:eTransmissionByZone][z,t])
 			end
 				
-			dfTemp1[t+rowoffset,14] = value(EP[:eAdditionalDemand][z,t])
+			dfTemp1[t+rowoffset,14] = value(EP[:eAdditionalDemandByZone][z,t])
 
 			if setup["ParameterScale"] == 1
 				dfTemp1[t+rowoffset,1] = dfTemp1[t+rowoffset,1] * ModelScalingFactor

--- a/src/GenX/write_outputs/write_power_balance.jl
+++ b/src/GenX/write_outputs/write_power_balance.jl
@@ -99,7 +99,7 @@ function write_power_balance(path::AbstractString, sep::AbstractString, inputs::
 				dfTemp1[t+rowoffset,13] = value(EP[:eTransmissionByZone][z,t])
 			end
 				
-			dfTemp1[t+rowoffset,14] = value(EP[:eAdditionalDemandByZone][z,t])
+			dfTemp1[t+rowoffset,14] = value(EP[:eAdditionalDemandByZone][t,z])
 
 			if setup["ParameterScale"] == 1
 				dfTemp1[t+rowoffset,1] = dfTemp1[t+rowoffset,1] * ModelScalingFactor

--- a/src/HSC/model/core/h2_non_served.jl
+++ b/src/HSC/model/core/h2_non_served.jl
@@ -116,6 +116,14 @@ function h2_non_served(EP::Model, inputs::Dict, setup::Dict)
     # Add non-served energy/curtailed demand contribution to power balance expression
     EP[:eH2Balance] += eH2BalanceNse
 
+    @expression(
+        EP,
+        eHNonServedDemand[z = 1:Z, t = 1:T],
+        sum(vH2NSE[s, t, z] for s = 1:H2_SEG)
+    )
+
+    EP[:eHDemandByZone] -= eHNonServedDemand
+    
     ### Constratints ###
 
     # Demand curtailed in each segment of curtailable demands cannot exceed maximum allowable share of demand

--- a/src/HSC/model/core/h2_non_served.jl
+++ b/src/HSC/model/core/h2_non_served.jl
@@ -116,13 +116,7 @@ function h2_non_served(EP::Model, inputs::Dict, setup::Dict)
     # Add non-served energy/curtailed demand contribution to power balance expression
     EP[:eH2Balance] += eH2BalanceNse
 
-    @expression(
-        EP,
-        eHNonServedDemand[z = 1:Z, t = 1:T],
-        sum(vH2NSE[s, t, z] for s = 1:H2_SEG)
-    )
-
-    EP[:eHDemandByZone] -= eHNonServedDemand
+    EP[:eHDemandByZone] -= eH2BalanceNse
     
     ### Constratints ###
 

--- a/src/HSC/model/generation/h2_production.jl
+++ b/src/HSC/model/generation/h2_production.jl
@@ -49,5 +49,7 @@ function h2_production(EP::Model, inputs::Dict, setup::Dict)
 		sum(EP[:vH2Gen][y,t] for y in intersect(inputs["H2_GEN"], dfH2Gen[dfH2Gen[!,:Zone].==z,:R_ID]))
 	)
 
+	EP[:eHGenerationByZone] += eH2GenerationByZone
+
 	return EP
 end

--- a/src/HSC/model/transmission/h2_pipeline.jl
+++ b/src/HSC/model/transmission/h2_pipeline.jl
@@ -201,16 +201,7 @@ function h2_pipeline(EP::Model, inputs::Dict, setup::Dict)
 
     EP[:eH2Balance] += ePipeZoneDemand
 
-    @expression(
-        EP,
-        eHTransimissionByPipeline[z = 1:Z, t = 1:T],
-        sum(
-            eH2PipeFlow_net[p, t, H2_Pipe_Map[(H2_Pipe_Map[!, :Zone].==z).&(H2_Pipe_Map[!, :pipe_no].==p), :][!,:d][1]] 
-            for p in H2_Pipe_Map[H2_Pipe_Map[!, :Zone].==z, :][!, :pipe_no]
-        )
-    )
-
-    EP[:eHTransmissionByZone] += eHTransmissionByPipeline
+    EP[:eHTransmissionByZone] += ePipeZoneDemand
 
     ## End Balance Expressions ##
     ### End Expressions ###

--- a/src/HSC/model/transmission/h2_pipeline.jl
+++ b/src/HSC/model/transmission/h2_pipeline.jl
@@ -201,6 +201,17 @@ function h2_pipeline(EP::Model, inputs::Dict, setup::Dict)
 
     EP[:eH2Balance] += ePipeZoneDemand
 
+    @expression(
+        EP,
+        eHTransimissionByPipeline[z = 1:Z, t = 1:T],
+        sum(
+            eH2PipeFlow_net[p, t, H2_Pipe_Map[(H2_Pipe_Map[!, :Zone].==z).&(H2_Pipe_Map[!, :pipe_no].==p), :][!,:d][1]] 
+            for p in H2_Pipe_Map[H2_Pipe_Map[!, :Zone].==z, :][!, :pipe_no]
+        )
+    )
+
+    EP[:eHTransmissionByZone] += eHTransmissionByPipeline
+
     ## End Balance Expressions ##
     ### End Expressions ###
 

--- a/src/HSC/model/truck/h2_truck_all.jl
+++ b/src/HSC/model/truck/h2_truck_all.jl
@@ -254,12 +254,7 @@ function h2_truck_all(EP::Model, inputs::Dict, setup::Dict)
     )
     EP[:eH2Balance] += eH2TruckFlow
 
-    @expression(
-        EP,
-        eHTransimissionByTruck[z = 1:Z, t = 1:T],
-        sum(vH2TruckFlow[z, j, t] for j in H2_TRUCK_TYPES)
-    )
-    EP[:eHTransmissionByZone] += eHTransmissionByTruck
+    EP[:eHTransmissionByZone] += eH2TruckFlow
 
     # H2 Truck Traveling Consumption balance
     @expression(

--- a/src/HSC/model/truck/h2_truck_all.jl
+++ b/src/HSC/model/truck/h2_truck_all.jl
@@ -254,6 +254,13 @@ function h2_truck_all(EP::Model, inputs::Dict, setup::Dict)
     )
     EP[:eH2Balance] += eH2TruckFlow
 
+    @expression(
+        EP,
+        eHTransimissionByTruck[z = 1:Z, t = 1:T],
+        sum(vH2TruckFlow[z, j, t] for j in H2_TRUCK_TYPES)
+    )
+    EP[:eHTransmissionByZone] += eHTransmissionByTruck
+
     # H2 Truck Traveling Consumption balance
     @expression(
         EP,

--- a/src/HSC/write_outputs/write_h2_balance.jl
+++ b/src/HSC/write_outputs/write_h2_balance.jl
@@ -21,11 +21,11 @@ Function for reporting hydrogen balance.
 """
 function write_h2_balance(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 	dfH2Gen = inputs["dfH2Gen"]
-	
+
 	if setup["ModelH2G2P"] == 1
 		dfH2G2P = inputs["dfH2G2P"]
 	end
-	
+
 	T = inputs["T"]     # Number of time steps (hours)
 	Z = inputs["Z"]     # Number of zones
 	H2_SEG = inputs["H2_SEG"] # Number of load curtailment segments
@@ -35,14 +35,14 @@ function write_h2_balance(path::AbstractString, sep::AbstractString, inputs::Dic
 	dfH2Balance = Array{Any}
 	rowoffset=3
 	for z in 1:Z
-	   	dfTemp1 = Array{Any}(nothing, T+rowoffset, 10)
-	   	dfTemp1[1,1:size(dfTemp1,2)] = ["Generation", 
+	   	dfTemp1 = Array{Any}(nothing, T+rowoffset, 11)
+	   	dfTemp1[1,1:size(dfTemp1,2)] = ["Generation",
 	           "Flexible_Demand_Defer", "Flexible_Demand_Satisfy",
 			   "Storage Discharging", "Storage Charging",
                "Nonserved_Energy",
 			   "H2_Pipeline_Import/Export",
 			   "H2_Truck_Import/Export","G2P Demand",
-	           "Demand"]
+	           "Demand", "Transmission"]
 	   	dfTemp1[2,1:size(dfTemp1,2)] = repeat([z],size(dfTemp1,2))
 	   	for t in 1:T
 	     	dfTemp1[t+rowoffset,1]= sum(value.(EP[:vH2Gen][dfH2Gen[(dfH2Gen[!,:H2_GEN_TYPE].>0) .&  (dfH2Gen[!,:Zone].==z),:][!,:R_ID],t]))
@@ -81,12 +81,14 @@ function write_h2_balance(path::AbstractString, sep::AbstractString, inputs::Dic
 		# end
 
 			if setup["ModelH2G2P"] == 1
-				dfTemp1[t+rowoffset,9] = sum(value.(EP[:vH2G2P][dfH2G2P[(dfH2G2P[!,:Zone].==z),:][!,:R_ID],t])) 
+				dfTemp1[t+rowoffset,9] = sum(value.(EP[:vH2G2P][dfH2G2P[(dfH2G2P[!,:Zone].==z),:][!,:R_ID],t]))
 			else
 				dfTemp1[t+rowoffset,9] = 0
 			end
 
 	     	dfTemp1[t+rowoffset,10] = -inputs["H2_D"][t,z]
+
+			dfTemp1[t+rowoffset,11] = value.(EP[:eHTransmissionByZone][t,z])
 
 	   	end
 

--- a/src/generate_model.jl
+++ b/src/generate_model.jl
@@ -181,7 +181,9 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 
 	###### START OF H2 INFRASTRUCTURE MODEL --- SHOULD BE A SEPARATE FILE?? ###############
 	if setup["ModelH2"] == 1
-
+		@expression(EP, eHGenerationByZone[z=1:Z, t=1:T], 0)
+		@expression(EP, eHTransmissionByZone[z=1:Z, t=1:T], 0)
+		@expression(EP, eHDemandByZone[z=1:Z, t=1:T], inputs["H2_D"][t, z])
 		# Net Power consumption by HSC supply chain by z and timestep - used in emissions constraints
 		@expression(EP, eH2NetpowerConsumptionByAll[t=1:T,z=1:Z], 0)	
 

--- a/src/generate_model.jl
+++ b/src/generate_model.jl
@@ -116,7 +116,7 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 	# Power supply by z and timestep - used in emissions constraints
 	@expression(EP, eGenerationByZone[z=1:Z, t=1:T], 0)
 	@expression(EP, eTransmissionByZone[z=1:Z, t=1:T], 0)
-	@expression(EP, eDemandByZone[z=1:Z, t=1:T], inputs["pD"][t, z])
+	@expression(EP, eDemandByZone[t=1:T, z=1:Z], inputs["pD"][t, z])
 	# Additional demand by z and timestep - used to record power consumption in other sectors like hydrogen and carbon
 	@expression(EP, eAdditionalDemandByZone[t=1:T, z=1:Z], 0)	
 
@@ -182,8 +182,8 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 	###### START OF H2 INFRASTRUCTURE MODEL --- SHOULD BE A SEPARATE FILE?? ###############
 	if setup["ModelH2"] == 1
 		@expression(EP, eHGenerationByZone[z=1:Z, t=1:T], 0)
-		@expression(EP, eHTransmissionByZone[z=1:Z, t=1:T], 0)
-		@expression(EP, eHDemandByZone[z=1:Z, t=1:T], inputs["H2_D"][t, z])
+		@expression(EP, eHTransmissionByZone[t=1:T, z=1:Z], 0)
+		@expression(EP, eHDemandByZone[t=1:T, z=1:Z], inputs["H2_D"][t, z])
 		# Net Power consumption by HSC supply chain by z and timestep - used in emissions constraints
 		@expression(EP, eH2NetpowerConsumptionByAll[t=1:T,z=1:Z], 0)	
 

--- a/src/generate_model.jl
+++ b/src/generate_model.jl
@@ -116,7 +116,7 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 	# Power supply by z and timestep - used in emissions constraints
 	@expression(EP, eGenerationByZone[z=1:Z, t=1:T], 0)
 	@expression(EP, eTransmissionByZone[z=1:Z, t=1:T], 0)
-	@expression(EP, eDemandByZone[z=1:Z, t=1:T], inputs["pD"][z, t])
+	@expression(EP, eDemandByZone[z=1:Z, t=1:T], inputs["pD"][t, z])
 	# Additional demand by z and timestep - used to record power consumption in other sectors like hydrogen and carbon
 	@expression(EP, eAdditionalDemandByZone[z=1:Z, t=1:T], 0)	
 

--- a/src/generate_model.jl
+++ b/src/generate_model.jl
@@ -118,7 +118,7 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 	@expression(EP, eTransmissionByZone[z=1:Z, t=1:T], 0)
 	@expression(EP, eDemandByZone[z=1:Z, t=1:T], inputs["pD"][t, z])
 	# Additional demand by z and timestep - used to record power consumption in other sectors like hydrogen and carbon
-	@expression(EP, eAdditionalDemandByZone[z=1:Z, t=1:T], 0)	
+	@expression(EP, eAdditionalDemandByZone[t=1:T, z=1:Z], 0)	
 
 	##### Power System related modules ############
 	EP = discharge(EP, inputs)
@@ -227,7 +227,7 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 			EP = h2_g2p(EP, inputs, setup)
 		end
 
-
+		EP[:eAdditionalDemandByZone] += EP[:eH2NetpowerConsumptionByAll]
 	end
 
 

--- a/src/generate_model.jl
+++ b/src/generate_model.jl
@@ -114,7 +114,11 @@ function generate_model(setup::Dict,inputs::Dict,OPTIMIZER::MOI.OptimizerWithAtt
 	@expression(EP, eObj, 0)
 
 	# Power supply by z and timestep - used in emissions constraints
-	@expression(EP, eGenerationByZone[z=1:Z, t=1:T], 0)	
+	@expression(EP, eGenerationByZone[z=1:Z, t=1:T], 0)
+	@expression(EP, eTransmissionByZone[z=1:Z, t=1:T], 0)
+	@expression(EP, eDemandByZone[z=1:Z, t=1:T], inputs["pD"][z, t])
+	# Additional demand by z and timestep - used to record power consumption in other sectors like hydrogen and carbon
+	@expression(EP, eAdditionalDemandByZone[z=1:Z, t=1:T], 0)	
 
 	##### Power System related modules ############
 	EP = discharge(EP, inputs)


### PR DESCRIPTION
In power sector, power balance plays the most important role in establishing the model and its composition will be more and more complicated if we keep adding more terms, which will definitely cause problem when writing power balance in results.

1. Add transmission term
2. Add demand term - inputs demand minus non served demand + additional demand from other sectors
3. Add additional demand
4. Write these terms in writing balance function

P.S. Hydrogen sector is not handled so additional demand is not processed. By the way expression eH2NetpowerConsumptionByAll could be used as part of additional demand but term additional demand could be extended if more sectors are to be added.