### PR TITLE
183 output file zone value incorrect

### DIFF
--- a/src/HSC/write_outputs/write_h2_pipeline_flow.jl
+++ b/src/HSC/write_outputs/write_h2_pipeline_flow.jl
@@ -30,21 +30,21 @@ function write_h2_pipeline_flow(path::AbstractString, sep::AbstractString, input
     dfPowerBalance = Array{Any}
     rowoffset=3
     for p in 1:H2_P
-           dfTemp1 = Array{Any}(nothing, T+rowoffset, 3)
-           dfTemp1[1,1:size(dfTemp1,2)] = ["Source_Zone_H2_Net", 
-               "Sink_Zone_H2_Net", "Pipe_Level"]
+        dfTemp1 = Array{Any}(nothing, T+rowoffset, 3)
+        dfTemp1[1,1:size(dfTemp1,2)] = ["Source_Zone_H2_Net", "Sink_Zone_H2_Net", "Pipe_Level"]
 
-           dfTemp1[2,1:size(dfTemp1,2)] = repeat([p],size(dfTemp1,2))
+        dfTemp1[2,1:size(dfTemp1,2)] = repeat([p],size(dfTemp1,2))
         
-        dfTemp1[3,1:size(dfTemp1,2)] = [[H2_Pipe_Map[(H2_Pipe_Map[!,:d] .== 1) .& (H2_Pipe_Map[!,:pipe_no] .== p), :][!,:zone_str][1]],[H2_Pipe_Map[(H2_Pipe_Map[!,:d] .== -1) .& (H2_Pipe_Map[!,:pipe_no] .== p), :][!,:zone_str][1]],"NA"]
+        zone_value1 = filter.(isdigit, ([H2_Pipe_Map[(H2_Pipe_Map[!,:d] .== 1) .& (H2_Pipe_Map[!,:pipe_no] .== p), :][!,:zone_str][1]][1]))
+        zone_value2 = filter.(isdigit, ([H2_Pipe_Map[(H2_Pipe_Map[!,:d] .== -1) .& (H2_Pipe_Map[!,:pipe_no] .== p), :][!,:zone_str][1]][1])) 
+        dfTemp1[3,1:size(dfTemp1,2)] = [zone_value1,zone_value2,"NA"]
 
-           for t in 1:T
-             dfTemp1[t+rowoffset,1]= value.(EP[:eH2PipeFlow_net][p,t,1])
-             dfTemp1[t+rowoffset,2] = value.(EP[:eH2PipeFlow_net][p,t,-1])
+        for t in 1:T
+            dfTemp1[t+rowoffset,1]= value.(EP[:eH2PipeFlow_net][p,t,1])
+            dfTemp1[t+rowoffset,2] = value.(EP[:eH2PipeFlow_net][p,t,-1])
             dfTemp1[t+rowoffset,3] = value.(EP[:vH2PipeLevel][p,t])
-             
-            
-           end
+        end
+
         if p==1
             dfPowerBalance =  hcat(vcat(["", "Pipe", "Zone"], ["t$t" for t in 1:T]), dfTemp1)
         else


### PR DESCRIPTION
# Description

The zone values in HSC_h2_pipeline_flow.csv are incorrect. This branch has fixes for that.

Fixes # (issue)
#183 
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Example_Systems/SmallNewEngland/OneZone 
- [x] Example_Systems/SmallNewEngland/ThreeZones
- [x] Example_Systems/SmallNewEngland/ThreeZones_Fluid
**Test Configuration**:
* OS: MacBook Pro Ventura 13.6
* Solver: Gurobi
* Julia version: 1.6.7

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
