### PR TITLE
Updated TDR to fix PeriodMap.csv error (Issue 250)

### DIFF
--- a/Example_Systems/SmallNewEngland/OneZone/Settings/time_domain_reduction_settings.yml
+++ b/Example_Systems/SmallNewEngland/OneZone/Settings/time_domain_reduction_settings.yml
@@ -15,7 +15,7 @@
   #   - TimestepsPerRepPeriod 
   #   Typically 168 timesteps (e.g., hours) per period, this designates 
   #   the length of each representative period.
-TimestepsPerRepPeriod: 168
+TimestepsPerRepPeriod: 24
 
   #   - ClusterMethod 
   #   Either 'kmeans' or 'kmedoids', this designates the method used to cluster
@@ -31,19 +31,19 @@ ScalingMethod: "S"
   #   The maximum number of periods - both clustered periods and extreme periods -
   #   that may be used to represent the input data. If IterativelyAddPeriods is on and the
   #   error threshold is never met, this will be the total number of periods.
-MaxPeriods: 3
+MaxPeriods: 10
 
   #   - MinPeriods
   #   The minimum number of periods used to represent the input data. If using
   #   UseExtremePeriods, this must be at least the number of extreme periods requests. If 
   #   IterativelyAddPeriods if off, this will be the total number of periods.
-MinPeriods: 1
+MinPeriods: 10
 
   #   - IterativelyAddPeriods
   #   Either 'yes' or 'no', this designates whether or not to add periods
   #   until the error threshold between input data and represented data is met or the maximum
   #   number of periods is reached.
-IterativelyAddPeriods: 1
+IterativelyAddPeriods: 0
 
   #   - IterateMethod
   #   Either 'cluster' or 'extreme', this designates whether to add clusters to
@@ -78,7 +78,7 @@ WeightTotal: 8760
   #   Fuels_data_clustered.csv with reshaped fuel prices based on the number and size of the
   #   representative weeks, assuming a constant time series of fuel prices with length equal to the
   #   number of timesteps in the raw input data.
-ClusterFuelPrices: 1
+ClusterFuelPrices: 0
 
   #   - UseExtremePeriods 
   #   Either 'yes' or 'no', this designates whether or not to include
@@ -119,7 +119,7 @@ ExtremePeriods:
             Min: 0
          Integral:   
             Max: 0
-            Min: 1
+            Min: 0
       System:
          Absolute:
             Max: 0
@@ -134,7 +134,7 @@ ExtremePeriods:
             Min: 0  
          Integral:
             Max: 0
-            Min: 1
+            Min: 0
       System:
          Absolute:
             Max: 0


### PR DESCRIPTION
# Description

- Updated time_domain_reduction.jl to fix error in the assignment of representative period, which result in a d Rep_Period key not being equal to the period_index when the period that actually a representative period.   
- Each representative period should be used to represent the period of the year (column Period_Index of Period Map) corresponding to its Rep_Period key. That was not happening before due to a bug in Step 4 of the TDR procedure.
-
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Fixes issue \#

Please tag any associated issues here using the format `Fixes #<issue number>`. If there is no associated issue, please type `No associated issue`.

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- Tested on SmallNewEngland system, OneZone and ThreeZone_Gurobi for different TDR settings (extremeperiods =0 or 1, clusterfuelprices =0 or 1)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [X ] Example_Systems/SmallNewEngland/OneZone 
- [ X] Example_Systems/SmallNewEngland/ThreeZones_Gurobi

**Test Configuration**:
* OS: Windows
* Solver: HiGHs
* Julia version: 1.10.0
* Solver version: 1.7.2

# Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X ] I have run tests with my code to avoid compatibility issues
- [X ] Any dependent changes have been merged and published in downstream modules
